### PR TITLE
🔀 :: [#16] Makefile 스크립트 4.x 버전대로 이동

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 generate:
-	tuist fetch
+	tuist insatll
 	tuist generate
 
 ci_generate:
-	tuist fetch
+	tuist install
 	TUIST_ENV=CI tuist generate
 
 cd_generate:
-	tuist fetch
+	tuist install
 	TUIST_ENV=CD tuist generate
 
 clean:


### PR DESCRIPTION
## 개요
#14 에서 내부 코드에 대해서는 4.x 업그레이드를 대응했지만 Makefile의 컨텐츠를 변경하는 것이 누락되어 픽스합니다 🥺 